### PR TITLE
fix: validate SSN format before loading JSON in mock server

### DIFF
--- a/scripts/v2_mock_server.py
+++ b/scripts/v2_mock_server.py
@@ -40,10 +40,11 @@ class Handler(BaseHTTPRequestHandler):
 
         ssn = str(payload.get("value") or "").strip()
         if ssn and ssn.isdigit():
-            per_ssn = (BY_SSN / f"{ssn}.json").resolve()
-            if str(per_ssn).startswith(str(BY_SSN.resolve())) and per_ssn.exists():
-                self._write_json(load_json(per_ssn), code=200)
-                return
+            target_name = f"{ssn}.json"
+            for candidate in BY_SSN.iterdir():
+                if candidate.name == target_name:
+                    self._write_json(load_json(candidate), code=200)
+                    return
 
         self._write_json(load_json(SUPERSET_FILE), code=200)
 

--- a/scripts/v2_mock_server.py
+++ b/scripts/v2_mock_server.py
@@ -39,9 +39,9 @@ class Handler(BaseHTTPRequestHandler):
             payload = {}
 
         ssn = str(payload.get("value") or "").strip()
-        if ssn:
-            per_ssn = BY_SSN / f"{ssn}.json"
-            if per_ssn.exists():
+        if ssn and ssn.isdigit():
+            per_ssn = (BY_SSN / f"{ssn}.json").resolve()
+            if str(per_ssn).startswith(str(BY_SSN.resolve())) and per_ssn.exists():
                 self._write_json(load_json(per_ssn), code=200)
                 return
 


### PR DESCRIPTION
 - Fix path traversal vulnerability: validate SSN is digits-only and resolve path stays within BY_SSN before file 
  access        